### PR TITLE
Update environment variable treatment.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - name: clone repo
         uses: actions/checkout@v2.0.0
       - name: install deno
-        uses: denolib/setup-deno@v1.2.0
+        uses: denolib/setup-deno@v1.3.0
       - name: run tests
         run: deno test --allow-env --allow-read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
       - name: install deno
         uses: denolib/setup-deno@v1.3.0
       - name: run tests
-        run: deno test --allow-env --allow-read
+        run: deno test --unstable --allow-env --allow-read

--- a/mod.ts
+++ b/mod.ts
@@ -87,7 +87,7 @@ function parse(file: string) {
 /** Derives aws config from the environment and/or filesystem. */
 export function get(opts: GetOptions = {}): { [key: string]: string; } {
   const _opts = { ...opts, env: opts.env !== false };
-  const ENV: { [key: string]: any; } = _opts.env ? Deno.env() : {};
+  const ENV: { [key: string]: any; } = _opts.env ? Deno.env.toObject() : {};
 
   _opts.fs = _opts.fs !== false;
   _opts.profile = _opts.profile || ENV.AWS_PROFILE || "default";

--- a/test.ts
+++ b/test.ts
@@ -1,9 +1,7 @@
 import { assertEquals } from "https://deno.land/std@v0.34.0/testing/asserts.ts";
 import { get } from "./mod.ts";
 
-const ENV = Deno.env();
-
-ENV.AWS_PROFILE = "default";
+Deno.env.set("AWS_PROFILE", "default")
 
 Deno.test({
   name: "returns an empty object if fs and env access are both disabled",
@@ -80,9 +78,9 @@ Deno.test({
 Deno.test({
   name: "getting it with no config argument",
   fn() {
-    ENV.AWS_SHARED_CREDENTIALS_FILE = "./test_credentials";
-    ENV.AWS_CONFIG_FILE = "./test_config";
-    ENV.AWS_PROFILE = "project2";
+    Deno.env.set("AWS_SHARED_CREDENTIALS_FILE", "./test_credentials");
+    Deno.env.set("AWS_CONFIG_FILE", "./test_config")
+    Deno.env.set("AWS_PROFILE", "project2");
 
     const got = get();
 


### PR DESCRIPTION
Deno made breaking change around `Deno.env`(https://github.com/denoland/deno/pull/4942), `Deno.env()` is now unavailable and we should use `Deno.env.toObject()` instead.

I have updated the code so we can use this with the latest Deno. Also I have updated test, which looked `ENV` was not propagated, and add unstable flag to test run because it is unstable now(https://github.com/denoland/deno/issues/4933).

Thanks!